### PR TITLE
Korrektion von Zeit und Ort der nächsten Event

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
         <div class="col-lg-8 col-lg-offset-2">
             <h2>Termine</h2>
 
-            <p>Das nächste Treffen wird am Freitag den 08.05.2015 von 16:30 Uhr bis 18:30 Uhr im Seminarraum 131 der Fakultät für
+            <p>Das nächste Treffen wird am Freitag den 08.05.2015 von 16:30 Uhr bis 18:30 Uhr im Seminarraum 236 der Fakultät für
                 Informatik am KIT stattfinden.</p>
 
             <p>Die unten aufgelisteten Termine finden alle im Gebäude 50.34 des KIT statt. Es gehört zur Fakultät für

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
         <div class="col-lg-8 col-lg-offset-2">
             <h2>Termine</h2>
 
-            <p>Das nächste Treffen wird am Freitag den 10.04.2015 von 16:30 Uhr bis 18:30 Uhr im Seminarraum 131 der Fakultät für
+            <p>Das nächste Treffen wird am Freitag den 08.05.2015 von 16:30 Uhr bis 18:30 Uhr im Seminarraum 131 der Fakultät für
                 Informatik am KIT stattfinden.</p>
 
             <p>Die unten aufgelisteten Termine finden alle im Gebäude 50.34 des KIT statt. Es gehört zur Fakultät für


### PR DESCRIPTION
Auf dem Timeline ist die Event am 8. Mai schon gekennzeichnet, aber im Fließtext davor wird noch eine frühere als nächste genannt. Diese Diskrepanz habe ich aufgehoben.
