### PR TITLE
Fetch events from CoderDojo Zen API

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 
     <!-- AngularJS base and data scripts -->
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular-resource.min.js"></script>
     <script src="js/angular/webApp.js"></script>
     <script src="js/data/eventList.js"></script>
     <script src="js/angular/eventController.js"></script>

--- a/js/angular/eventController.js
+++ b/js/angular/eventController.js
@@ -1,4 +1,17 @@
-app.controller('eventController', function($scope) {
+app.controller('eventController', function($scope, EventService) {
+
+    $scope.eventListZen = EventService.search({
+        query : {
+            dojoId : "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+            status : "published",
+            filterPastEvents : false,
+            limit$ : 10,
+            skip$ : 0,
+            sort$ : {
+                createdAt : -1
+            }
+        }
+    });
 
     $scope.eventList = eventList; // from global var in data script
     $scope.pastEventList = []; // filled in init

--- a/js/angular/webApp.js
+++ b/js/angular/webApp.js
@@ -1,4 +1,10 @@
-var app = angular.module('webApp', []);
+var app = angular.module('webApp', ['ngResource']);
+
+app.factory('EventService', function ($resource) {
+    return $resource('https://zen.coderdojo.com/api/2.0/events/search', null, {
+	    'search': {method: 'POST', isArray: true},
+	});
+});
 
 app.run(function($rootScope) {
     $rootScope.color = 'blue';

--- a/js/data/eventListZen.js
+++ b/js/data/eventListZen.js
@@ -1,0 +1,944 @@
+eventListZenSample =
+[
+    {
+        "entity$": "-/cd/events",
+        "id": "5e7e62fd-e7c3-46a5-8a23-46c4f5ca6d3c",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-10-28T11:10:35.745Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 11.11.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-11-11T17:00:00.000Z",
+                "endTime": "2016-11-11T19:00:00.000Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "61df11a4-8d73-4fd2-962a-5e600aa3c514",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "5e7e62fd-e7c3-46a5-8a23-46c4f5ca6d3c",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "522e2829-c8e3-4d98-ba81-138b88b330eb",
+                        "sessionId": "61df11a4-8d73-4fd2-962a-5e600aa3c514",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 4,
+                        "approvedApplications": 4
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "3d6200fa-96da-4d15-a8cf-18c32e058ecd",
+                        "sessionId": "61df11a4-8d73-4fd2-962a-5e600aa3c514",
+                        "name": "Getränke/Snacks",
+                        "type": "other",
+                        "quantity": 1,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "b9c5daa8-2c47-4b63-afc2-eb07096a1d91",
+                        "sessionId": "61df11a4-8d73-4fd2-962a-5e600aa3c514",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 12,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 9,
+                        "approvedApplications": 9
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "b62bfbf3-a072-49ae-b3c6-52904b84ec84",
+                        "sessionId": "61df11a4-8d73-4fd2-962a-5e600aa3c514",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 8,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 1,
+                        "approvedApplications": 1
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "d55af069-a355-44c5-9291-dfab7f031046",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-10-26T14:26:59.927Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 28.10.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-10-28T17:00:00.000Z",
+                "endTime": "2016-10-28T19:00:00.000Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "bc972ad6-2db5-43cb-8773-f0b89b983aa0",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "d55af069-a355-44c5-9291-dfab7f031046",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "efd21497-7354-454e-a8df-beafc0323f0b",
+                        "sessionId": "bc972ad6-2db5-43cb-8773-f0b89b983aa0",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 3,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 3,
+                        "approvedApplications": 3
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "cacea464-6e9d-4d79-bc04-41b9e0c50eb5",
+                        "sessionId": "bc972ad6-2db5-43cb-8773-f0b89b983aa0",
+                        "name": "Getränke/Snacks",
+                        "type": "other",
+                        "quantity": 1,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "953767d3-0145-4ace-83de-6302a4feea8b",
+                        "sessionId": "bc972ad6-2db5-43cb-8773-f0b89b983aa0",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 14,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 13,
+                        "approvedApplications": 12
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "a3da8903-7fad-44f8-acfa-fecec83bdef4",
+                        "sessionId": "bc972ad6-2db5-43cb-8773-f0b89b983aa0",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 8,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 4,
+                        "approvedApplications": 4
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "22307f1c-5f45-4587-995d-4d0d2e06541b",
+        "name": "Dojo zur CodeWeek",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-10-07T08:29:33.188Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 14.10.2016. Sonderveranstaltung zur CodeWeek.</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-10-14T17:00:56.694Z",
+                "endTime": "2016-10-14T19:00:56.694Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "375782ef-106d-495e-af42-9d9a2d496680",
+                "name": "SR 236",
+                "description": "Ein etwas anderes Dojo. Falls ein Freund/eine Freundin oder ein Geschwisterkind mitkommt, bitte bei der Anmeldung ins Kommentarfeld Name und Alter eintragen.",
+                "eventId": "22307f1c-5f45-4587-995d-4d0d2e06541b",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "09d6c0cd-c964-4076-bbaf-f18b78f0c6e9",
+                        "sessionId": "375782ef-106d-495e-af42-9d9a2d496680",
+                        "name": "Teilnehmer Dojo zur CodeWeek",
+                        "type": "ninja",
+                        "quantity": 15,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 13,
+                        "approvedApplications": 13
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "45043904-590a-416c-9d7e-bbaf9914d689",
+                        "sessionId": "375782ef-106d-495e-af42-9d9a2d496680",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "fd83ae4f-00f3-4f77-8601-cc4d2f840b0f",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-09-18T19:39:58.681Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 30.09.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-09-30T17:00:12.377Z",
+                "endTime": "2016-09-30T19:00:12.377Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "7e68e460-a804-431a-be89-5fbeff343a39",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "fd83ae4f-00f3-4f77-8601-cc4d2f840b0f",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "13af74b2-2f39-47ff-b023-e39bcf15e73f",
+                        "sessionId": "7e68e460-a804-431a-be89-5fbeff343a39",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 4,
+                        "approvedApplications": 4
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "4a66dee4-a760-48a1-8430-857002bb116d",
+                        "sessionId": "7e68e460-a804-431a-be89-5fbeff343a39",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "816d8ce0-3089-42d8-9988-61f6096b6bd0",
+                        "sessionId": "7e68e460-a804-431a-be89-5fbeff343a39",
+                        "name": "Getränke/Snacks",
+                        "type": "other",
+                        "quantity": 1,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "9d676ff7-6a77-4ea1-82ee-0ae08265e927",
+                        "sessionId": "7e68e460-a804-431a-be89-5fbeff343a39",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 12,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 12,
+                        "approvedApplications": 12
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "be8a82fa-554b-409d-a29e-cf72061f66b9",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-08-30T09:16:34.914Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 16.09.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-09-16T17:00:33.720Z",
+                "endTime": "2016-09-16T19:00:33.720Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "acc5eb70-eda3-4644-945c-523350bbce6a",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "be8a82fa-554b-409d-a29e-cf72061f66b9",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "f47de1d2-7eb3-4a35-a745-83dfd6e2e534",
+                        "sessionId": "acc5eb70-eda3-4644-945c-523350bbce6a",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 2,
+                        "approvedApplications": 2
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "7d24f53b-d892-4e31-b2f9-e83486705983",
+                        "sessionId": "acc5eb70-eda3-4644-945c-523350bbce6a",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "97eb2820-bbc3-4454-a38f-d48245d2b7fd",
+                        "sessionId": "acc5eb70-eda3-4644-945c-523350bbce6a",
+                        "name": "Getränke/Snacks",
+                        "type": "other",
+                        "quantity": 1,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 1,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "7009e553-17d2-4cbd-851d-f1e015bc9f5d",
+                        "sessionId": "acc5eb70-eda3-4644-945c-523350bbce6a",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 12,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 7,
+                        "approvedApplications": 7
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "ac7b80c4-9978-46cb-8397-a7c27a326994",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-07-30T21:08:57.664Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 26.08.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-08-26T17:00:50.732Z",
+                "endTime": "2016-08-26T19:00:50.732Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "3b0a7ed5-72d0-4ebc-baf3-d13ca73fc5a0",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "ac7b80c4-9978-46cb-8397-a7c27a326994",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "27e5c8dd-5b9c-4cf7-ab46-2e1203e6ec28",
+                        "sessionId": "3b0a7ed5-72d0-4ebc-baf3-d13ca73fc5a0",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 1,
+                        "approvedApplications": 1
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "60275ae4-ae88-42ed-a476-2ccb01f39271",
+                        "sessionId": "3b0a7ed5-72d0-4ebc-baf3-d13ca73fc5a0",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "06a0d8d9-9f77-4a8d-ad2a-70765fe78e52",
+                        "sessionId": "3b0a7ed5-72d0-4ebc-baf3-d13ca73fc5a0",
+                        "name": "Getränke/Snacks",
+                        "type": "other",
+                        "quantity": 1,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "f6cf2055-2aff-482c-ae1f-8629d1cf2dd4",
+                        "sessionId": "3b0a7ed5-72d0-4ebc-baf3-d13ca73fc5a0",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 12,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 2,
+                        "approvedApplications": 2
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "65102d61-daaf-444a-91ac-5e176bec1c10",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-07-06T20:31:51.382Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 29.07.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-07-29T17:00:13.443Z",
+                "endTime": "2016-07-29T19:00:13.443Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "aa0807bf-81a3-425d-bab7-01175f933cc6",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "65102d61-daaf-444a-91ac-5e176bec1c10",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "ccbb6fe1-5d14-41cd-95e6-e20041099f87",
+                        "sessionId": "aa0807bf-81a3-425d-bab7-01175f933cc6",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 1,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "127fe160-53cc-4a82-b634-8d30e05bfaa7",
+                        "sessionId": "aa0807bf-81a3-425d-bab7-01175f933cc6",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 12,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 7,
+                        "approvedApplications": 7
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "b3eca354-154d-494f-910c-8cad80436498",
+                        "sessionId": "aa0807bf-81a3-425d-bab7-01175f933cc6",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 3,
+                        "approvedApplications": 3
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "f98f18b0-b8e1-409f-bc01-d00561b1c869",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-07-06T20:31:48.921Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 15.07.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-07-15T17:00:24.566Z",
+                "endTime": "2016-07-15T19:00:24.566Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "e4382e76-5eef-4ee1-889b-1c3c0e092b6e",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "f98f18b0-b8e1-409f-bc01-d00561b1c869",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "9066092b-9849-4977-ad67-c0cb99d579b0",
+                        "sessionId": "e4382e76-5eef-4ee1-889b-1c3c0e092b6e",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "a38aa899-d916-4aa3-be8c-4f46dad7155c",
+                        "sessionId": "e4382e76-5eef-4ee1-889b-1c3c0e092b6e",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 9,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 9,
+                        "approvedApplications": 9
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "54ae1706-5c18-48ea-87b4-3f6b32ff901d",
+                        "sessionId": "e4382e76-5eef-4ee1-889b-1c3c0e092b6e",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 3,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 2,
+                        "approvedApplications": 2
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "c809fdb0-e8a4-49b0-a564-3ed42b6c0c34",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-06-03T14:38:08.902Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 17.06.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-06-17T17:00:20.437Z",
+                "endTime": "2016-06-17T19:00:20.437Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "b1395cc9-257a-4533-9544-38d1622379ef",
+                "name": "SR 236",
+                "description": null,
+                "eventId": "c809fdb0-e8a4-49b0-a564-3ed42b6c0c34",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "245d2c02-9b9b-4b79-a298-62ad370dd573",
+                        "sessionId": "b1395cc9-257a-4533-9544-38d1622379ef",
+                        "name": "Meine erste Website - Workshop",
+                        "type": "ninja",
+                        "quantity": 6,
+                        "deleted": 0,
+                        "invites": [
+                            {
+                                "userId": "f2e798f7-6a65-45be-a9df-31de70fe85b9",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "28d29d0c-b7a8-477e-a934-556b88cd5ac6",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "eae2568e-0a29-454e-b1f5-48ad830fafe4",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "38f6d7f9-a527-4b2c-b53a-a28d0ac049cc",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "f4ae9cf6-8a43-4b5e-a51a-c3e6bbd1b72c",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "2a1359bd-9545-44fa-a16d-de00c97986e4",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "a492d036-e9cc-425f-9566-9df5ff99c643",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "6a0a6733-f142-4743-b94a-1e11a4dbf40a",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "dd0bd0a5-abb8-4881-9474-f5f8eb0a03b2",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "2c204374-f4b7-434d-ae4d-7ef5fded5764",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "a10e5cac-c29a-46f3-ac9e-fb12b1ab743b",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "e1e27b2a-c042-463f-a988-26ffe3e43152",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "9750cd43-e684-4606-8a37-bb401999fe56",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "740f7ada-58cb-4b4a-8bfb-cec338a4ad25",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "c9386466-de74-4b29-a2eb-2db0dbcfd19d",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "90f12766-5e32-4642-ac0a-0765cba0ed7b",
+                                "userNotified": true
+                            },
+                            {
+                                "userId": "86b2abee-f7ae-499e-b201-dc6c0198f78f",
+                                "userNotified": true
+                            }
+                        ],
+                        "totalApplications": 8,
+                        "approvedApplications": 8
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "2e526d6b-e337-4fac-877f-ee9147c499ae",
+                        "sessionId": "b1395cc9-257a-4533-9544-38d1622379ef",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": [],
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "e0c231a4-3340-49f9-89b7-aa2e93722a36",
+                        "sessionId": "b1395cc9-257a-4533-9544-38d1622379ef",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 6,
+                        "deleted": 0,
+                        "invites": [],
+                        "totalApplications": 3,
+                        "approvedApplications": 3
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "56a9550a-0902-47ef-a52a-6f7a912a30aa",
+                        "sessionId": "b1395cc9-257a-4533-9544-38d1622379ef",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": [],
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "entity$": "-/cd/events",
+        "id": "44109fe3-eca8-4f36-81e0-cda37a317b3a",
+        "name": "Dojo in Karlsruhe",
+        "country": {
+            "countryName": "Germany",
+            "alpha2": "DE"
+        },
+        "city": {
+            "nameWithHierarchy": "Karlsruhe"
+        },
+        "address": "Karlsruher Institut für Technologie (KIT)\nFakultät für Informatik\nGebäude 50.34\nAm Fasanengarten 5\n76131 Karlsruhe</p>",
+        "createdAt": "2016-06-03T14:37:39.755Z",
+        "createdBy": null,
+        "type": "one-off",
+        "description": "<p>Dojo am 01.07.2016</p>\n",
+        "dojoId": "55a9b83e-9188-45f5-8a6a-72f0af31aad2",
+        "position": {
+            "lat": 49.01380839999999,
+            "lng": 8.419531000000006
+        },
+        "public": true,
+        "status": "published",
+        "recurringType": "weekly",
+        "dates": [
+            {
+                "startTime": "2016-07-01T17:00:20.437Z",
+                "endTime": "2016-07-01T19:00:20.437Z"
+            }
+        ],
+        "ticketApproval": true,
+        "sessions": [
+            {
+                "entity$": "-/cd/sessions",
+                "id": "9d4c7e0a-1bc0-4e2a-a11a-0e939f64c405",
+                "name": "SR 301 im 3. OG!!",
+                "description": null,
+                "eventId": "44109fe3-eca8-4f36-81e0-cda37a317b3a",
+                "status": "active",
+                "tickets": [
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "450747cb-0879-4251-8c98-b3aa4c4fba74",
+                        "sessionId": "9d4c7e0a-1bc0-4e2a-a11a-0e939f64c405",
+                        "name": "Teilnehmer mit Laptop",
+                        "type": "ninja",
+                        "quantity": 6,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 6,
+                        "approvedApplications": 6
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "96745226-ba16-4e22-a255-be9a2735ac1d",
+                        "sessionId": "9d4c7e0a-1bc0-4e2a-a11a-0e939f64c405",
+                        "name": "Mentor",
+                        "type": "mentor",
+                        "quantity": 10,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 0,
+                        "approvedApplications": 0
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "ec656559-e3fe-4f14-9904-9e6a14122622",
+                        "sessionId": "9d4c7e0a-1bc0-4e2a-a11a-0e939f64c405",
+                        "name": "Teilnehmer ohne Laptop",
+                        "type": "ninja",
+                        "quantity": 4,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 3,
+                        "approvedApplications": 3
+                    },
+                    {
+                        "entity$": "-/cd/tickets",
+                        "id": "f5246793-5c3d-40eb-ba66-cc4c898531b8",
+                        "sessionId": "9d4c7e0a-1bc0-4e2a-a11a-0e939f64c405",
+                        "name": "Meine erste Website - Workshop",
+                        "type": "ninja",
+                        "quantity": 6,
+                        "deleted": 0,
+                        "invites": null,
+                        "totalApplications": 3,
+                        "approvedApplications": 3
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
We are solely using the CoderDojo Zen platform to manage our events. It would make it a lot easier if there is only a single point where time, space etc. is coordinated.

This is currently work in progress and due to Cross-Origin Resource Sharing depends on CoderDojo allowing public access to the API.

Note: Sample output of the API is provided. CORS can be disabled for development until API is public.

The current task list ist:
- [x] Implement service to fetch the list of events from the Zen API
- [ ] Migrate from current eventlist format to Zen API compatible format
- [ ] Load data using the service
- [x] Create pull request/issue with request to make the API public and link this PR for reference